### PR TITLE
Mingw changes

### DIFF
--- a/patches/zlib-1.2.5-PPU.patch
+++ b/patches/zlib-1.2.5-PPU.patch
@@ -1,6 +1,6 @@
 diff -burN orig.zlib-1.2.5/Makefile.in zlib-1.2.5/Makefile.in
---- orig.zlib-1.2.5/Makefile.in	2010-04-20 01:12:21.000000000 -0300
-+++ zlib-1.2.5/Makefile.in	2010-11-20 20:53:51.731875494 -0400
+--- orig.zlib-1.2.5/Makefile.in	2010-04-20 00:12:21 -0400
++++ zlib-1.2.5/Makefile.in	2011-03-06 00:58:14 -0500
 @@ -69,7 +69,7 @@
  
  all: static shared
@@ -18,3 +18,17 @@ diff -burN orig.zlib-1.2.5/Makefile.in zlib-1.2.5/Makefile.in
  	cd $(DESTDIR)$(libdir); chmod u=rw,go=r $(STATICLIB)
  	-@(cd $(DESTDIR)$(libdir); $(RANLIB) libz.a || true) >/dev/null 2>&1
  	-@cd $(DESTDIR)$(sharedlibdir); if test "$(SHAREDLIBV)" -a -f $(SHAREDLIBV); then \
+diff -burN orig.zlib-1.2.5/configure zlib-1.2.5/configure
+--- orig.zlib-1.2.5/configure	2010-04-20 00:15:19 -0400
++++ zlib-1.2.5/configure	2011-03-06 01:11:35 -0500
+@@ -124,8 +124,8 @@
+   MINGW*|mingw*)
+ # temporary bypass
+         rm -f $test.[co] $test $test$shared_ext
+-        echo "Please use win32/Makefile.gcc instead."
+-        exit 1
++#        echo "Please use win32/Makefile.gcc instead."
++#        exit 1
+         LDSHARED=${LDSHARED-"$cc -shared"}
+         LDSHAREDLIBC=""
+         EXE='.exe' ;;

--- a/scripts/008-libvorbis-1.3.2.sh
+++ b/scripts/008-libvorbis-1.3.2.sh
@@ -15,7 +15,7 @@ mkdir build-ppu && cd build-ppu || { exit 1; }
 
 ## Configure the build.
 CFLAGS="-I$PS3DEV/host/ppu/include" \
-LDFLAGS="-L$PS3DEV/host/ppu/lib -L$PSL1GHT/lib" \
+LDFLAGS="-L$PS3DEV/host/ppu/lib -L$PSL1GHT/lib -lm" \
 PKG_CONFIG_PATH="$PS3DEV/host/ppu/lib/pkgconfig" \
 ../configure --prefix="$PS3DEV/host/ppu" --host="ppu" --disable-shared || { exit 1; }
 


### PR DESCRIPTION
All ps3libraries build successfully with these changes under mingw, when having all of the dependancies set up with toolchain-mingw.sh
