### PR TITLE
Update zlib-1.2.6.sh to zlib-1.2.7.sh as it fails the build now.

### DIFF
--- a/scripts/001-zlib-1.2.6.sh
+++ b/scripts/001-zlib-1.2.6.sh
@@ -2,10 +2,10 @@
 # zlib-1.2.6.sh by Dan Peori (danpeori@oopo.net)
 
 ## Download the source code.
-wget --continue http://zlib.net/zlib-1.2.6.tar.gz
+wget --continue http://zlib.net/zlib-1.2.7.tar.gz
 
 ## Unpack the source code.
-rm -Rf zlib-1.2.6 && tar xfvz zlib-1.2.6.tar.gz && cd zlib-1.2.6
+rm -Rf zlib-1.2.6 && tar xfvz zlib-1.2.7.tar.gz && cd zlib-1.2.7
 
 ## Patch the source code.
 cat ../../patches/zlib-1.2.6-PPU.patch | patch -p1


### PR DESCRIPTION
hello guys this is just a small thing i don't know if anything else needs to be changed but the build failed for me because the zlib-1.2.6 or zlib.1.2.5 are not available anymore for download it was upgraded to zlib-1.2.7
