### PR TITLE
Fix the freetype link error

### DIFF
--- a/scripts/004-freetype-2.4.3.sh
+++ b/scripts/004-freetype-2.4.3.sh
@@ -2,7 +2,7 @@
 # freetype-2.4.3.sh by Dan Peori (danpeori@oopo.net)
 
 ## Download the source code.
-wget --continue http://voxel.dl.sourceforge.net/project/freetype/freetype2/2.4.3/freetype-2.4.3.tar.gz
+wget --continue http://download.savannah.gnu.org/releases/freetype/freetype-2.4.3.tar.gz
 
 ## Unpack the source code.
 rm -Rf freetype-2.4.3 && tar xfvz freetype-2.4.3.tar.gz && cd freetype-2.4.3


### PR DESCRIPTION
The sourceforge link was invalid so I have switched the freetype download link to another mirror at:

http://download.savannah.gnu.org/releases/freetype/freetype-2.4.3.tar.gz
