### PR TITLE
Fix Freetype URL

### DIFF
--- a/scripts/004-freetype-2.4.3.sh
+++ b/scripts/004-freetype-2.4.3.sh
@@ -2,7 +2,7 @@
 # freetype-2.4.3.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --continue http://download.savannah.gnu.org/releases/freetype/freetype-2.4.3.tar.gz
+wget --continue http://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz
 
 ## Download an up-to-date config.guess and config.sub
 if [ ! -f config.guess ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi


### PR DESCRIPTION
Freetype moved around their tarballs and the used URL is not valid anymore.
Use the correct one.