### PR TITLE
FIX: links for freetype and libxml2

### DIFF
--- a/scripts/004-freetype-2.4.3.sh
+++ b/scripts/004-freetype-2.4.3.sh
@@ -2,7 +2,7 @@
 # freetype-2.4.3.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --continue http://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz
+wget --continue https://download-mirror.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz
 
 ## Download an up-to-date config.guess and config.sub
 if [ ! -f config.guess ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/012-libxml2-2.7.8.sh
+++ b/scripts/012-libxml2-2.7.8.sh
@@ -2,14 +2,14 @@
 # libxml2-2.7.8.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --continue http://xmlsoft.org/download/libxml2-2.7.8.tar.gz
+wget --continue https://download.gnome.org/sources/libxml2/2.7/libxml2-2.7.8.tar.xz
 
 ## Download an up-to-date config.guess and config.sub
 if [ ! -f config.guess ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi
 if [ ! -f config.sub ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.sub; fi
 
 ## Unpack the source code.
-rm -Rf libxml2-2.7.8 && tar xfvz libxml2-2.7.8.tar.gz && cd libxml2-2.7.8
+rm -Rf libxml2-2.7.8 && tar xfvJ libxml2-2.7.8.tar.xz && cd libxml2-2.7.8
 
 ## Replace config.guess and config.sub
 cp ../config.guess ../config.sub .


### PR DESCRIPTION
Freetype:

`download.savannah.gnu.org` returns 502 on any file in `releases/freetype/freetype-old/` as far as I checked. `download-mirror` works fine.

libxml2:

Whole `xmlsoft.org` has been moved to `gitlab.gnome.org/GNOME/libxml2`.