### PR TITLE
Update 012-libxml2-2.7.8.sh to point the download URL to a working URL

### DIFF
--- a/scripts/012-libxml2-2.7.8.sh
+++ b/scripts/012-libxml2-2.7.8.sh
@@ -2,7 +2,7 @@
 # libxml2-2.7.8.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --continue http://xmlsoft.org/download/libxml2-2.7.8.tar.gz
+wget --continue http://xmlsoft.org/sources/libxml2-2.7.8.tar.gz
 
 ## Download an up-to-date config.guess and config.sub
 if [ ! -f config.guess ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi


### PR DESCRIPTION
The old URL results in a 404 error. This change would make it point to a working URL.