### PR TITLE
Set `AR` in 011-libmikmod-3.1.11.sh

### DIFF
--- a/scripts/011-libmikmod-3.1.11.sh
+++ b/scripts/011-libmikmod-3.1.11.sh
@@ -17,6 +17,7 @@ mkdir build-ppu && cd build-ppu
 CFLAGS="-I$PSL1GHT/ppu/include -I$PS3DEV/portlibs/ppu/include" \
 LDFLAGS="-L$PSL1GHT/ppu/lib -L$PS3DEV/portlibs/ppu/lib -lrt -llv2" \
 CC="powerpc64-ps3-elf-gcc" LD="powerpc64-ps3-elf-ld" NM="powerpc64-ps3-elf-nm" \
+AR="powerpc64-ps3-elf-ar" \
 RANLIB="powerpc64-ps3-elf-ranlib" STRIP="powerpc64-ps3-elf-strip" \
 ../configure --prefix="$PS3DEV/portlibs/ppu" --host="powerpc64-ps3-elf" \
 --disable-esd --disable-dl --disable-shared


### PR DESCRIPTION
Set `AR=powerpc64-ps3-elf-ar` like the other library scripts.
On macOS current libmikmod script falls back to host `ar` which silently drops PowerPC ELF and leaves an empty `libmikmod.a`, breaking the SDL_mixer link.