### PR TITLE
Change freetype download link to SourceForge

### DIFF
--- a/archives/archives.txt
+++ b/archives/archives.txt
@@ -1,7 +1,7 @@
 b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30  1497445 https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
 d07616ba1e9c161017384feb3b576d70c160b970abfd9549ad39a622284b574a   829414 https://download.sourceforge.net/libpng/libpng-1.4.4.tar.gz
 64be2429346b1aa84a014fc47264661ca2e6c786aea25afecb363d5973b4e6a9   935594 https://www.ijg.org/files/jpegsrc.v8b.tar.gz
-33ec92273c2d809e51dece879c09d206e5dfa3d6deb7ce9e4c2bf0891b8111f9  1907043 https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz
+33ec92273c2d809e51dece879c09d206e5dfa3d6deb7ce9e4c2bf0891b8111f9  1907043 https://downloads.sourceforge.net/project/freetype/freetype2/2.4.3/freetype-2.4.3.tar.gz
 9c02c22c6cc3f28f3633d02ef6f0cac130518f621edb011ebbbf08cd1a81251a   537274 https://cairographics.org/releases/pixman-0.20.0.tar.gz
 0f2ce4cc4615594088d74eb8b5360bad7c3cc3c3da9b61af9bfd979ed1ed94b2 24022822 https://cairographics.org/releases/cairo-1.10.0.tar.gz
 fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e   589570 https://downloads.xiph.org/releases/ogg/libogg-1.3.4.tar.gz


### PR DESCRIPTION
Updated the download link for freetype from Savannah to SourceForge.