### PR TITLE
Fix pthread_t initialization issues in testThreads.c and libxml2

### DIFF
--- a/patches/libxml2-2.7.8-pthread.patch
+++ b/patches/libxml2-2.7.8-pthread.patch
@@ -1,9 +1,12 @@
-@@ -107,7 +107,7 @@
- #if defined(HAVE_PTHREAD_H) && !defined(_WIN32)
-        for (i = 0; i < num_threads; i++) {
-            results[i] = NULL;
--           tid[i] = (pthread_t) -1;
-+           memset(&tid[i], 0, sizeof(pthread_t));
-        }
- #endif
-        for (i = 0; i < num_threads; i++) {
+diff --git a/testThreads.c b/testThreads.c
+index b43cbd0..5c12894 100644
+--- a/testThreads.c
++++ b/testThreads.c
+@@ -107,7 +107,6 @@ main(void)
+ 
+ 	for (i = 0; i < num_threads; i++) {
+ 	    results[i] = NULL;
+-	    tid[i] = (pthread_t) -1;
+ 	}
+ 
+ 	for (i = 0; i < num_threads; i++) {

--- a/patches/libxml2-2.7.8-pthread.patch
+++ b/patches/libxml2-2.7.8-pthread.patch
@@ -1,0 +1,9 @@
+@@ -107,7 +107,7 @@
+ #if defined(HAVE_PTHREAD_H) && !defined(_WIN32)
+        for (i = 0; i < num_threads; i++) {
+            results[i] = NULL;
+-           tid[i] = (pthread_t) -1;
++           memset(&tid[i], 0, sizeof(pthread_t));
+        }
+ #endif
+        for (i = 0; i < num_threads; i++) {

--- a/scripts/012-libxml2-2.7.8.sh
+++ b/scripts/012-libxml2-2.7.8.sh
@@ -19,6 +19,10 @@ echo "Unpacking ${LIBXML2}"
 extract ../archives/${LIBXML2}.tar.gz
 cd ${LIBXML2}
 
+## Patch pthread_t issue for modern toolchains
+echo "Patching testThreads.c..."
+patch -p1 < ../../patches/${LIBXML2}-pthread.patch
+
 ## Replace config.guess and config.sub
 cp ../../archives/config.guess ../../archives/config.sub .
 


### PR DESCRIPTION
This pull request addresses a compatibility issue with `pthread_t` initialization in `libxml2` for modern toolchains. The main change ensures that thread IDs are properly zero-initialized, and the patch is now applied during the build process.

### Thread initialization fix

* Updated `patches/libxml2-2.7.8-pthread.patch` to replace the assignment of `(pthread_t) -1` with `memset` to zero-initialize `pthread_t` variables, improving compatibility with modern compilers.

### Build script update

* Modified `scripts/012-libxml2-2.7.8.sh` to apply the pthread patch automatically during the build, ensuring the fix is consistently used.